### PR TITLE
Deprecated PIDCommand, still need to remove usage

### DIFF
--- a/src/main/kotlin/frc/team3324/library/commands/PIDCommand.kt
+++ b/src/main/kotlin/frc/team3324/library/commands/PIDCommand.kt
@@ -4,6 +4,7 @@ import edu.wpi.first.wpilibj.Notifier
 import edu.wpi.first.wpilibj2.command.CommandBase
 import edu.wpi.first.wpilibj2.command.Subsystem
 
+@Deprecated(level = DeprecationLevel.HIDDEN, message = "Should be replaced with WPILib conforming PIDCommand")
 class PIDCommand(val kP: Double, val kI: Double, val kD: Double, val goal: Double, val dt: Double, subsystem: Subsystem, val measurement: () -> Double, val useOutput: (Double) -> Unit): CommandBase() {
     private var integral = 0.0
     private var lastPosition = 0.0


### PR DESCRIPTION
I wrote PIDCommand for the 2019 arm, back when the integral term on the
WPILib PIDCommand didn't reset the integral. We both should not be using
the integral term (idealy) and this problem is now solved in WPILib,
making this class redundant. (#6) 