### PR TITLE
Moved Climber to MotorSubsystem

### DIFF
--- a/src/main/kotlin/frc/team3324/library/commands/MotorCommand.kt
+++ b/src/main/kotlin/frc/team3324/library/commands/MotorCommand.kt
@@ -3,9 +3,9 @@ package frc.team3324.library.commands
 import edu.wpi.first.wpilibj2.command.CommandBase
 import frc.team3324.library.subsystems.MotorSubsystem
 
-class MotorCommand(val subsystem: MotorSubsystem, val speed: Double): CommandBase() {
+class MotorCommand(val subsystem: MotorSubsystem, val motorName: String, val speed: Double): CommandBase() {
     override fun execute() {
-        subsystem.speed = speed
+        subsystem.setSpeed(motorName, speed)
     }
 
     override fun isFinished(): Boolean {

--- a/src/main/kotlin/frc/team3324/library/subsystems/MotorSubsystem.kt
+++ b/src/main/kotlin/frc/team3324/library/subsystems/MotorSubsystem.kt
@@ -3,16 +3,21 @@ package frc.team3324.library.subsystems
 import com.ctre.phoenix.motorcontrol.NeutralMode
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
 import edu.wpi.first.wpilibj2.command.SubsystemBase
-import frc.team3324.library.commands.MotorCommand
 
-class MotorSubsystem(val motor: WPI_TalonSRX, val currentLimit: Int, val defaultSpeed: Double = 0.0): SubsystemBase() {
+class MotorSubsystem(val motorMap: Map<String, WPI_TalonSRX>, val currentLimit: Int, val defaultSpeed: Double = 0.0): SubsystemBase() {
     init {
-        motor.setNeutralMode(NeutralMode.Brake)
-        motor.configContinuousCurrentLimit(currentLimit)
-        motor.enableCurrentLimit(true)
+        for (motor in motorMap.values) {
+            motor.setNeutralMode(NeutralMode.Brake)
+            motor.configContinuousCurrentLimit(currentLimit)
+            motor.enableCurrentLimit(true)
+        }
     }
 
-    var speed: Double
-        get() = motor.get()
-        set(input) = motor.set(input)
+    fun setSpeed(motorName: String, speed: Double) {
+        motorMap.get(motorName)?.set(speed)
+    }
+
+    fun getSpeed(motorName: String) {
+        motorMap.get(motorName)?.get()
+    }
 }

--- a/src/main/kotlin/frc/team3324/robot/RobotContainer.kt
+++ b/src/main/kotlin/frc/team3324/robot/RobotContainer.kt
@@ -1,10 +1,12 @@
 package frc.team3324.robot
 
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
 import edu.wpi.first.networktables.NetworkTableInstance
 import edu.wpi.first.wpilibj.*
 import edu.wpi.first.wpilibj.XboxController.Button
 import edu.wpi.first.wpilibj2.command.Command
 import edu.wpi.first.wpilibj2.command.button.JoystickButton
+import frc.team3324.library.commands.MotorCommand
 import frc.team3324.robot.autocommands.FinalAutoGroup
 import frc.team3324.robot.climber.Climber
 import frc.team3324.robot.climber.commands.RunClimber
@@ -25,13 +27,14 @@ import frc.team3324.robot.storage.commands.RunStorageConstant
 import frc.team3324.robot.util.Camera
 import frc.team3324.robot.util.Consts
 import frc.team3324.library.commands.ToggleLightCommand
+import frc.team3324.library.subsystems.MotorSubsystem
 import io.github.oblarg.oblog.Logger
 
 class RobotContainer {
     private val intake = Intake()
     private val storage = Storage()
     private val driveTrain = DriveTrain()
-    private val climber = Climber()
+    private val climber = MotorSubsystem(mapOf("leftMotor" to WPI_TalonSRX(Consts.Climber.MOTOR_LEFT), "rightMotor" to WPI_TalonSRX(Consts.Climber.MOTOR_RIGHT)), 40)
     private val pivot = Pivot()
     private val shooter = Shooter()
 
@@ -85,10 +88,10 @@ class RobotContainer {
         JoystickButton(primaryController, Button.kBumperLeft.value).whileHeld(PivotPID(pivot, -90.0))
         JoystickButton(primaryController, Button.kBumperRight.value).whileHeld(PivotPID(pivot, 0.0))
         JoystickButton(primaryController, Button.kX.value).whenPressed(ToggleLightCommand(Robot.light))
-        JoystickButton(primaryController, Button.kA.value).whileHeld(RunClimber(climber, -1.0, {input: Double -> climber.leftSpeed = input}))
-        JoystickButton(primaryController, Button.kB.value).whileHeld(RunClimber(climber, -1.0, {input: Double -> climber.rightSpeed = input}))
-        JoystickButton(primaryController, Button.kStickLeft.value).whileHeld(RunClimber(climber, 1.0, {input: Double -> climber.leftSpeed = input}))
-        JoystickButton(primaryController, Button.kStickRight.value).whileHeld(RunClimber(climber, 1.0, {input: Double -> climber.rightSpeed = input}))
+        JoystickButton(primaryController, Button.kA.value).whileHeld(MotorCommand(climber, "leftMotor", -1.0)) // run the left climber motor
+        JoystickButton(primaryController, Button.kB.value).whileHeld(MotorCommand(climber, "rightMotor", -1.0)) // run the right climber motor
+        JoystickButton(primaryController, Button.kStickLeft.value).whileHeld(MotorCommand(climber, "leftMotor", 1.0))
+        JoystickButton(primaryController, Button.kStickRight.value).whileHeld(MotorCommand(climber, "rightMotor", 1.0))
         JoystickButton(primaryController, Button.kY.value).whileHeld(GyroTurn(
                 driveTrain,
                 1.0/80.0,

--- a/src/main/kotlin/frc/team3324/robot/shooter/commands/RunShooter.kt
+++ b/src/main/kotlin/frc/team3324/robot/shooter/commands/RunShooter.kt
@@ -18,7 +18,7 @@ class RunShooter(val shooter: Shooter, val area: () -> Double, val trench: Boole
         if (trench) {
             rpm = 1116 * Math.pow(area(), -0.338)
         }
-       shooter.RPM = rpm
+        shooter.RPM = rpm
         Robot.robotContainer.rumbleController(1.0)
     }
 


### PR DESCRIPTION
Moved the climber object to MotorSubsystem class instead of Climber
class. Climber still exists in the code for reference, but isn't used
anywhere. MotorSubsystem now is constructed with a map for multiple
motors and their names.