### PR TITLE
Ported Intake to Library

### DIFF
--- a/src/main/kotlin/frc/team3324/library/commands/MotorCommand.kt
+++ b/src/main/kotlin/frc/team3324/library/commands/MotorCommand.kt
@@ -4,6 +4,10 @@ import edu.wpi.first.wpilibj2.command.CommandBase
 import frc.team3324.library.subsystems.MotorSubsystem
 
 class MotorCommand(val subsystem: MotorSubsystem, val motorName: String, val speed: Double): CommandBase() {
+    init {
+        addRequirements(subsystem)
+    }
+
     override fun execute() {
         subsystem.setSpeed(motorName, speed)
     }

--- a/src/main/kotlin/frc/team3324/library/subsystems/MotorSubsystem.kt
+++ b/src/main/kotlin/frc/team3324/library/subsystems/MotorSubsystem.kt
@@ -4,7 +4,7 @@ import com.ctre.phoenix.motorcontrol.NeutralMode
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
 import edu.wpi.first.wpilibj2.command.SubsystemBase
 
-class MotorSubsystem(val motorMap: Map<String, WPI_TalonSRX>, val currentLimit: Int, val defaultSpeed: Double = 0.0): SubsystemBase() {
+open class MotorSubsystem(val motorMap: Map<String, WPI_TalonSRX>, val currentLimit: Int, val defaultSpeed: Double = 0.0): SubsystemBase() {
     init {
         for (motor in motorMap.values) {
             motor.setNeutralMode(NeutralMode.Brake)
@@ -17,7 +17,7 @@ class MotorSubsystem(val motorMap: Map<String, WPI_TalonSRX>, val currentLimit: 
         motorMap.get(motorName)?.set(speed)
     }
 
-    fun getSpeed(motorName: String) {
-        motorMap.get(motorName)?.get()
+    fun getMotor(motorName: String): WPI_TalonSRX? {
+        return motorMap.get(motorName)
     }
 }

--- a/src/main/kotlin/frc/team3324/robot/RobotContainer.kt
+++ b/src/main/kotlin/frc/team3324/robot/RobotContainer.kt
@@ -8,16 +8,12 @@ import edu.wpi.first.wpilibj2.command.Command
 import edu.wpi.first.wpilibj2.command.button.JoystickButton
 import frc.team3324.library.commands.MotorCommand
 import frc.team3324.robot.autocommands.FinalAutoGroup
-import frc.team3324.robot.climber.Climber
-import frc.team3324.robot.climber.commands.RunClimber
 import frc.team3324.robot.drivetrain.DriveTrain
 import frc.team3324.robot.drivetrain.commands.teleop.Drive
 import frc.team3324.robot.drivetrain.commands.teleop.GyroTurn
 import frc.team3324.robot.intake.Intake
 import frc.team3324.robot.intake.Pivot
 import frc.team3324.robot.intake.commands.PivotPID
-import frc.team3324.robot.intake.commands.RunIntake
-import frc.team3324.robot.intake.commands.RunIntakeConstant
 import frc.team3324.robot.intake.commands.RunPivot
 import frc.team3324.robot.shooter.Shooter
 import frc.team3324.robot.shooter.commands.RunShooter
@@ -28,6 +24,7 @@ import frc.team3324.robot.util.Camera
 import frc.team3324.robot.util.Consts
 import frc.team3324.library.commands.ToggleLightCommand
 import frc.team3324.library.subsystems.MotorSubsystem
+import frc.team3324.robot.util.physics.Motors
 import io.github.oblarg.oblog.Logger
 
 class RobotContainer {
@@ -79,7 +76,7 @@ class RobotContainer {
 
 
        pivot.defaultCommand = RunPivot(pivot, -0.05)
-       intake.defaultCommand = RunIntake(storage, intake, this::secondTriggerRight, this::secondTriggerLeft)
+       intake.defaultCommand = MotorCommand(intake, "leftMotor", if (secondTriggerRight > 0.0) secondTriggerRight * 0.5 else -secondTriggerLeft * 0.5)
        configureButtonBindings()
 
    }
@@ -103,13 +100,14 @@ class RobotContainer {
         JoystickButton(secondaryController, Button.kY.value).whenPressed(RunShooter(shooter, {cameraTable.getEntry("targetArea").getDouble(3800.0)}, true).withTimeout(10.0))
         JoystickButton(secondaryController, Button.kBumperLeft.value).whileHeld(RunStorageConstant(storage, 0.6))
         JoystickButton(secondaryController, Button.kBumperRight.value).whileHeld(RunStorageConstant(storage, -0.6))
-        JoystickButton(secondaryController, Button.kA.value).whileHeld(RunIntakeConstant(storage, intake, pivot,-1.0))
-        JoystickButton(secondaryController, Button.kB.value).whileHeld(RunIntakeConstant(storage, intake, pivot,1.0))
+
+        JoystickButton(secondaryController, Button.kA.value).whileHeld(MotorCommand(intake, "leftMotor", -1.0))
+        JoystickButton(secondaryController, Button.kB.value).whileHeld(MotorCommand(intake, "leftMotor", 1.0))
         JoystickButton(secondaryController, Button.kStart.value).whenPressed(StopShooter(shooter))
         JoystickButton(bongos, 1).whileHeld(RunStorageConstant(storage, 0.8))
         JoystickButton(bongos, 2).whileHeld(RunStorageConstant(storage, -0.8))
-        JoystickButton(bongos, 4).whileHeld(RunIntakeConstant(storage, intake, pivot, 1.0))
-        JoystickButton(bongos, 3).whileHeld(RunIntakeConstant(storage, intake, pivot, -1.0))
+        JoystickButton(bongos, 4).whileHeld(MotorCommand(intake, "leftMotor", 1.0))
+        JoystickButton(bongos, 3).whileHeld(MotorCommand(intake, "leftMotor", -1.0))
         JoystickButton(bongos, 10).whenPressed(RunShooter(shooter, {cameraTable.getEntry("targetArea").getDouble(3800.0)}, false).withTimeout(   10.0))
 
     }

--- a/src/main/kotlin/frc/team3324/robot/intake/Intake.kt
+++ b/src/main/kotlin/frc/team3324/robot/intake/Intake.kt
@@ -1,38 +1,23 @@
 package frc.team3324.robot.intake
 
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
-import edu.wpi.first.wpilibj2.command.SubsystemBase
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard
 import edu.wpi.first.wpilibj.DutyCycleEncoder
+import frc.team3324.library.subsystems.MotorSubsystem
 import io.github.oblarg.oblog.Loggable
 import io.github.oblarg.oblog.annotations.Log
 
-class Intake : SubsystemBase(), Loggable {
-    private val leftMotor = WPI_TalonSRX(20)
+class Intake: MotorSubsystem(mapOf("leftMotor" to WPI_TalonSRX(20)), 10), Loggable {
     private val dutyEncoder = DutyCycleEncoder(7)
 
-    var speed
-        @Log
-        get() = leftMotor.get()
-        set(x) = leftMotor.set(x)
-
-    val current
-        @Log
-        get() = leftMotor.statorCurrent
-
+    init {
+        this.getMotor("leftMotor")?.inverted = true
+    }
 
     private val radianMeasure: Double
         @Log
         get() = dutyEncoder.get()*2*Math.PI
 
-
-    init {
-        leftMotor.inverted = true
-        leftMotor.configContinuousCurrentLimit(10)
-        leftMotor.enableCurrentLimit(true)
-    }
-
-    override fun periodic() {
-    }
-
+    val current
+        @Log
+        get() = this.getMotor("leftMotor")?.statorCurrent
 }

--- a/src/main/kotlin/frc/team3324/robot/intake/commands/RunIntake.kt
+++ b/src/main/kotlin/frc/team3324/robot/intake/commands/RunIntake.kt
@@ -2,9 +2,8 @@ package frc.team3324.robot.intake.commands
 
 import edu.wpi.first.wpilibj2.command.CommandBase
 import frc.team3324.robot.intake.Intake
-import frc.team3324.robot.storage.Storage
 
-class RunIntake(val storage: Storage, val intake: Intake, val speedOne: () -> Double, val speedTwo: () -> Double): CommandBase() {
+class RunIntake(val intake: Intake, val speedOne: () -> Double, val speedTwo: () -> Double): CommandBase() {
 
     init {
         addRequirements(intake)
@@ -12,16 +11,16 @@ class RunIntake(val storage: Storage, val intake: Intake, val speedOne: () -> Do
 
     override fun execute() {
         if (speedOne() > 0.0) {
-            intake.speed = speedOne() * 0.5
+            intake.setSpeed("leftMotor", speedOne() * 0.5)
         } else if (speedTwo() > 0.0) {
-            intake.speed = -speedTwo() * 0.5
+            intake.setSpeed("leftMotor", -speedTwo() * 0.5)
         } else {
-            intake.speed = 0.0
+            intake.setSpeed("leftMotor", 0.0)
         }
     }
 
     override fun end(interrupted: Boolean) {
-        intake.speed = 0.0
+        intake.setSpeed("leftMotor", 0.0)
     }
 
 }

--- a/src/main/kotlin/frc/team3324/robot/intake/commands/RunIntakeConstant.kt
+++ b/src/main/kotlin/frc/team3324/robot/intake/commands/RunIntakeConstant.kt
@@ -14,12 +14,12 @@ class RunIntakeConstant(val storage: Storage, val intake: Intake, val pivot: Piv
 
     override fun execute() {
         pivot.pivot = 0.07
-        intake.speed = speed
+        intake.setSpeed("leftMotor", speed)
 //        storage.botSpeed = 0.6 * -sign(speed)
     }
 
     override fun end(interrupted: Boolean) {
         storage.botSpeed = 0.0
-        intake.speed = 0.0
+        intake.setSpeed("leftMotor", 0.0)
     }
 }


### PR DESCRIPTION
Changed robot/intake/Intake.kt to extend MotorSubsystem, reducing
redundant code (Issue #5). Moved all intake commands in RobotContainer.kt to MotorCommands. Changed all intake commands to use the new Intake subsystem, in case they still need to be used. Tweaked MotorSubsystem for better use when it's being inherited from.