### PR TITLE
Wrap both TalonSRXs and SparkMAXes into one interface

### DIFF
--- a/src/main/kotlin/frc/team3324/library/motorcontrollers/MetroSparkMAX.kt
+++ b/src/main/kotlin/frc/team3324/library/motorcontrollers/MetroSparkMAX.kt
@@ -1,0 +1,29 @@
+package frc.team3324.library.motorcontrollers
+
+import com.revrobotics.CANSparkMax
+import com.revrobotics.CANSparkMaxLowLevel
+
+class MetroSparkMAX(deviceID: Int, type: CANSparkMaxLowLevel.MotorType, currentLimit: Int) : CANSparkMax(deviceID, type), SmartMotorController {
+    init {
+        this.setSmartCurrentLimit(currentLimit);
+    }
+
+    override fun follow(motor: SmartMotorController, invert: Boolean) {
+        this.follow(motor as CANSparkMax, invert)
+    }
+
+    override fun setCurrentLimit(value: Int) {
+        this.setSmartCurrentLimit(value)
+    }
+
+    override fun getCurrentDraw(): Double {
+        return this.outputCurrent
+    }
+
+    override fun setNeutralMode(mode: SmartMotorController.MetroNeutralMode) {
+        this.idleMode = when (mode) {
+            SmartMotorController.MetroNeutralMode.BRAKE -> IdleMode.kBrake
+            SmartMotorController.MetroNeutralMode.COAST -> IdleMode.kCoast
+        }
+    }
+}

--- a/src/main/kotlin/frc/team3324/library/motorcontrollers/MetroTalonSRX.kt
+++ b/src/main/kotlin/frc/team3324/library/motorcontrollers/MetroTalonSRX.kt
@@ -1,0 +1,32 @@
+package frc.team3324.library.motorcontrollers
+
+import com.ctre.phoenix.motorcontrol.NeutralMode
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
+
+class MetroTalonSRX(deviceNumber: Int, currentLimit: Int) : WPI_TalonSRX(deviceNumber), SmartMotorController {
+    init {
+        this.enableCurrentLimit(true)
+        this.setCurrentLimit(currentLimit)
+    }
+
+    override fun follow(motor: SmartMotorController, invert: Boolean) {
+        this.follow(motor as WPI_TalonSRX)
+    }
+
+    override fun setCurrentLimit(value: Int) {
+        this.configContinuousCurrentLimit(value)
+    }
+
+    override fun getCurrentDraw(): Double {
+        return this.statorCurrent
+    }
+
+    override fun setNeutralMode(mode: SmartMotorController.MetroNeutralMode) {
+        this.setNeutralMode(
+                when (mode) {
+                    SmartMotorController.MetroNeutralMode.BRAKE -> NeutralMode.Brake
+                    SmartMotorController.MetroNeutralMode.COAST -> NeutralMode.Coast
+                }
+        )
+    }
+}

--- a/src/main/kotlin/frc/team3324/library/motorcontrollers/SmartMotorController.kt
+++ b/src/main/kotlin/frc/team3324/library/motorcontrollers/SmartMotorController.kt
@@ -1,0 +1,12 @@
+package frc.team3324.library.motorcontrollers
+
+import com.revrobotics.CANSparkMax
+import edu.wpi.first.wpilibj.SpeedController
+
+interface SmartMotorController: SpeedController {
+    enum class MetroNeutralMode {BRAKE, COAST}
+    fun setCurrentLimit(value: Int)
+    fun getCurrentDraw(): Double
+    fun follow(motor: SmartMotorController, invert: Boolean)
+    fun setNeutralMode(mode: MetroNeutralMode)
+}

--- a/src/main/kotlin/frc/team3324/library/subsystems/MotorSubsystem.kt
+++ b/src/main/kotlin/frc/team3324/library/subsystems/MotorSubsystem.kt
@@ -3,21 +3,20 @@ package frc.team3324.library.subsystems
 import com.ctre.phoenix.motorcontrol.NeutralMode
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
 import edu.wpi.first.wpilibj2.command.SubsystemBase
+import frc.team3324.library.motorcontrollers.SmartMotorController
 
-open class MotorSubsystem(val motorMap: Map<String, WPI_TalonSRX>, val currentLimit: Int, val defaultSpeed: Double = 0.0): SubsystemBase() {
+open class MotorSubsystem(private val motorMap: Map<String, SmartMotorController>, val defaultSpeed: Double = 0.0): SubsystemBase() {
     init {
         for (motor in motorMap.values) {
-            motor.setNeutralMode(NeutralMode.Brake)
-            motor.configContinuousCurrentLimit(currentLimit)
-            motor.enableCurrentLimit(true)
+            motor.setNeutralMode(SmartMotorController.MetroNeutralMode.BRAKE)
         }
     }
 
     fun setSpeed(motorName: String, speed: Double) {
-        motorMap.get(motorName)?.set(speed)
+        motorMap[motorName]?.set(speed)
     }
 
-    fun getMotor(motorName: String): WPI_TalonSRX? {
-        return motorMap.get(motorName)
+    fun getMotor(motorName: String): SmartMotorController? {
+        return motorMap[motorName]
     }
 }

--- a/src/main/kotlin/frc/team3324/robot/RobotContainer.kt
+++ b/src/main/kotlin/frc/team3324/robot/RobotContainer.kt
@@ -23,15 +23,15 @@ import frc.team3324.robot.storage.commands.RunStorageConstant
 import frc.team3324.robot.util.Camera
 import frc.team3324.robot.util.Consts
 import frc.team3324.library.commands.ToggleLightCommand
+import frc.team3324.library.motorcontrollers.MetroTalonSRX
 import frc.team3324.library.subsystems.MotorSubsystem
-import frc.team3324.robot.util.physics.Motors
 import io.github.oblarg.oblog.Logger
 
 class RobotContainer {
     private val intake = Intake()
     private val storage = Storage()
     private val driveTrain = DriveTrain()
-    private val climber = MotorSubsystem(mapOf("leftMotor" to WPI_TalonSRX(Consts.Climber.MOTOR_LEFT), "rightMotor" to WPI_TalonSRX(Consts.Climber.MOTOR_RIGHT)), 40)
+    private val climber = MotorSubsystem(mapOf("leftMotor" to MetroTalonSRX(Consts.Climber.MOTOR_LEFT, 40), "rightMotor" to MetroTalonSRX(Consts.Climber.MOTOR_RIGHT, 40)), 40.0)
     private val pivot = Pivot()
     private val shooter = Shooter()
 
@@ -81,7 +81,7 @@ class RobotContainer {
 
    }
 
-    fun configureButtonBindings() {
+    private fun configureButtonBindings() {
         JoystickButton(primaryController, Button.kBumperLeft.value).whileHeld(PivotPID(pivot, -90.0))
         JoystickButton(primaryController, Button.kBumperRight.value).whileHeld(PivotPID(pivot, 0.0))
         JoystickButton(primaryController, Button.kX.value).whenPressed(ToggleLightCommand(Robot.light))

--- a/src/main/kotlin/frc/team3324/robot/intake/Intake.kt
+++ b/src/main/kotlin/frc/team3324/robot/intake/Intake.kt
@@ -2,11 +2,12 @@ package frc.team3324.robot.intake
 
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX
 import edu.wpi.first.wpilibj.DutyCycleEncoder
+import frc.team3324.library.motorcontrollers.MetroTalonSRX
 import frc.team3324.library.subsystems.MotorSubsystem
 import io.github.oblarg.oblog.Loggable
 import io.github.oblarg.oblog.annotations.Log
 
-class Intake: MotorSubsystem(mapOf("leftMotor" to WPI_TalonSRX(20)), 10), Loggable {
+class Intake: MotorSubsystem(mapOf("leftMotor" to MetroTalonSRX(20, 20)), 10.0), Loggable {
     private val dutyEncoder = DutyCycleEncoder(7)
 
     init {
@@ -19,5 +20,5 @@ class Intake: MotorSubsystem(mapOf("leftMotor" to WPI_TalonSRX(20)), 10), Loggab
 
     val current
         @Log
-        get() = this.getMotor("leftMotor")?.statorCurrent
+        get() = this.getMotor("leftMotor")?.getCurrentDraw()
 }


### PR DESCRIPTION
I went ahead and introduced a "SmartMotorController" interface, then
implemented it in two new classes: "MetroSparkMAX", and "MetroTalonSRX",
I'm not sure if I added everything we use but it's pretty easy to append
to. Hopefully this will be pretty easy to hook into if we need to switch
everything to Falcons or whatever in the future.